### PR TITLE
closes #44: switchable positions of categories and launchers

### DIFF
--- a/panel-plugin/configuration-dialog.cpp
+++ b/panel-plugin/configuration-dialog.cpp
@@ -229,6 +229,14 @@ void ConfigurationDialog::toggle_position_commands_alternate(GtkToggleButton* bu
 
 //-----------------------------------------------------------------------------
 
+void ConfigurationDialog::toggle_position_categories_alternate(GtkToggleButton* button)
+{
+	wm_settings->position_categories_alternate = gtk_toggle_button_get_active(button);
+	wm_settings->set_modified();
+}
+
+//-----------------------------------------------------------------------------
+
 void ConfigurationDialog::toggle_remember_favorites(GtkToggleButton* button)
 {
 	wm_settings->favorites_in_recent = gtk_toggle_button_get_active(button);
@@ -550,6 +558,12 @@ GtkWidget* ConfigurationDialog::init_appearance_tab()
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(m_position_commands_alternate), wm_settings->position_commands_alternate);
 	gtk_widget_set_sensitive(GTK_WIDGET(m_position_commands_alternate), wm_settings->position_commands_alternate);
 	g_signal_connect_slot(m_position_commands_alternate, "toggled", &ConfigurationDialog::toggle_position_commands_alternate, this);
+
+	// Add option to switch positions of categories and launchers
+	m_position_categories_alternate = gtk_check_button_new_with_mnemonic(_("Switch positions of categories and _launchers"));
+	gtk_box_pack_start(appearance_vbox, m_position_categories_alternate, true, true, 0);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(m_position_categories_alternate), wm_settings->position_categories_alternate);
+	g_signal_connect_slot(m_position_categories_alternate, "toggled", &ConfigurationDialog::toggle_position_categories_alternate, this);
 
 	// Add item icon size selector
 	hbox = GTK_BOX(gtk_hbox_new(false, 12));

--- a/panel-plugin/configuration-dialog.h
+++ b/panel-plugin/configuration-dialog.h
@@ -46,6 +46,7 @@ private:
 	void toggle_show_hierarchy(GtkToggleButton* button);
 	void toggle_position_search_alternate(GtkToggleButton* button);
 	void toggle_position_commands_alternate(GtkToggleButton* button);
+	void toggle_position_categories_alternate(GtkToggleButton* button);
 	void category_icon_size_changed(GtkComboBox* combo);
 	void item_icon_size_changed(GtkComboBox* combo);
 
@@ -82,6 +83,7 @@ private:
 	GtkWidget* m_show_hierarchy;
 	GtkWidget* m_position_search_alternate;
 	GtkWidget* m_position_commands_alternate;
+	GtkWidget* m_position_categories_alternate;
 	GtkWidget* m_category_icon_size;
 	GtkWidget* m_item_icon_size;
 

--- a/panel-plugin/settings.cpp
+++ b/panel-plugin/settings.cpp
@@ -100,6 +100,7 @@ Settings::Settings() :
 	display_recent(false),
 	position_search_alternate(false),
 	position_commands_alternate(false),
+	position_categories_alternate(false),
 
 	menu_width(400),
 	menu_height(500)
@@ -177,6 +178,7 @@ void Settings::load(char* file)
 	display_recent = xfce_rc_read_bool_entry(rc, "display-recent-default", display_recent);
 	position_search_alternate = xfce_rc_read_bool_entry(rc, "position-search-alternate", position_search_alternate);
 	position_commands_alternate = xfce_rc_read_bool_entry(rc, "position-commands-alternate", position_commands_alternate) && position_search_alternate;
+	position_categories_alternate = xfce_rc_read_bool_entry(rc, "position-categories-alternate", position_categories_alternate);
 
 	menu_width = std::max(300, xfce_rc_read_int_entry(rc, "menu-width", menu_width));
 	menu_height = std::max(400, xfce_rc_read_int_entry(rc, "menu-height", menu_height));
@@ -269,6 +271,7 @@ void Settings::save(char* file)
 	xfce_rc_write_bool_entry(rc, "display-recent-default", display_recent);
 	xfce_rc_write_bool_entry(rc, "position-search-alternate", position_search_alternate);
 	xfce_rc_write_bool_entry(rc, "position-commands-alternate", position_commands_alternate);
+	xfce_rc_write_bool_entry(rc, "position-categories-alternate", position_categories_alternate);
 
 	xfce_rc_write_int_entry(rc, "menu-width", menu_width);
 	xfce_rc_write_int_entry(rc, "menu-height", menu_height);

--- a/panel-plugin/settings.h
+++ b/panel-plugin/settings.h
@@ -78,6 +78,7 @@ public:
 	bool display_recent;
 	bool position_search_alternate;
 	bool position_commands_alternate;
+	bool position_categories_alternate;
 
 	enum Commands
 	{

--- a/panel-plugin/window.cpp
+++ b/panel-plugin/window.cpp
@@ -436,6 +436,17 @@ void Window::show(GtkWidget* parent, bool horizontal)
 			g_object_unref(m_commands_align);
 		}
 	}
+	if ((layout_left && !wm_settings->position_categories_alternate)
+			|| (!layout_left && wm_settings->position_categories_alternate))
+	{
+		gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_panels_box), 1);
+		gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_sidebar), 2);
+	}
+	else
+	{
+		gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_panels_box), 2);
+		gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_sidebar), 1);
+	}
 	if (layout_left != m_layout_left)
 	{
 		m_layout_left = layout_left;
@@ -454,9 +465,6 @@ void Window::show(GtkWidget* parent, bool horizontal)
 
 			gtk_box_reorder_child(m_search_box, GTK_WIDGET(m_search_entry), 0);
 			gtk_box_reorder_child(m_search_box, GTK_WIDGET(m_commands_align), 1);
-
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_panels_box), 1);
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_sidebar), 2);
 		}
 		else if (m_layout_commands_alternate)
 		{
@@ -473,9 +481,6 @@ void Window::show(GtkWidget* parent, bool horizontal)
 
 			gtk_box_reorder_child(m_search_box, GTK_WIDGET(m_search_entry), 1);
 			gtk_box_reorder_child(m_search_box, GTK_WIDGET(m_commands_align), 0);
-
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_panels_box), 2);
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_sidebar), 1);
 		}
 		else if (m_layout_left)
 		{
@@ -490,9 +495,6 @@ void Window::show(GtkWidget* parent, bool horizontal)
 			gtk_box_reorder_child(m_title_box, GTK_WIDGET(m_username), 0);
 			gtk_box_reorder_child(m_title_box, GTK_WIDGET(m_commands_align), 1);
 			gtk_box_reorder_child(m_title_box, GTK_WIDGET(m_resizer->get_widget()), 2);
-
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_panels_box), 1);
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_sidebar), 2);
 		}
 		else
 		{
@@ -507,9 +509,6 @@ void Window::show(GtkWidget* parent, bool horizontal)
 			gtk_box_reorder_child(m_title_box, GTK_WIDGET(m_username), 2);
 			gtk_box_reorder_child(m_title_box, GTK_WIDGET(m_commands_align), 1);
 			gtk_box_reorder_child(m_title_box, GTK_WIDGET(m_resizer->get_widget()), 0);
-
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_panels_box), 2);
-			gtk_box_reorder_child(m_contents_box, GTK_WIDGET(m_sidebar), 1);
 		}
 	}
 


### PR DESCRIPTION
Hopefully closes issue #44.

My first C++ in years. Hope all is well.

The new label, `"Switch positions of categories and _launchers"` is not yet in the pot file as I haven't absolutely the slightest idea how to operate that. :smiley: 
