### PR TITLE
possibly fixes issue #64, opens popup on keyup

### DIFF
--- a/panel-plugin/plugin.cpp
+++ b/panel-plugin/plugin.cpp
@@ -344,19 +344,21 @@ void Plugin::orientation_changed(XfcePanelPlugin*, GtkOrientation orientation)
 
 gboolean Plugin::remote_event(XfcePanelPlugin*, gchar* name, GValue* value)
 {
-	if (strcmp(name, "popup") == 0 && panel_utils_grab_available())
+	if (strcmp(name, "popup") || !panel_utils_grab_available())
 	{
-		if (gtk_widget_get_visible(m_window->get_widget()))
-		{
-			m_window->hide();
-		}
-		else
-		{
-			popup_menu(value && G_VALUE_HOLDS_BOOLEAN(value) && g_value_get_boolean(value));
-		}
-		return true;
+		return false;
 	}
-	return false;
+
+	if (gtk_widget_get_visible(m_window->get_widget()))
+	{
+		m_window->hide();
+	}
+	else
+	{
+		popup_menu(value && G_VALUE_HOLDS_BOOLEAN(value) && g_value_get_boolean(value));
+	}
+
+	return true;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This perhaps fixes issue #64.

I've looked how [xfce4-applicationsmenu-plugin](http://git.xfce.org/xfce/xfce4-panel/tree/plugins/applicationsmenu/applicationsmenu.c?id=xfce4-panel-4.10.1#n692) does it. It's not perfect. I won't say I understand the code, but the behavior is somewhat quirky: If `<Super>` is bound to whiskermenu popup and `<Super>+T` to Terminal, `<Super>+T` opens up Terminal as expected, but also whiskermenu if `<Super>` is released within 1/4 of a second (as defined in the auxiliary function).

How to improve it, I haven't got a clue. :smiley_cat: 
