### PR TITLE
Set menu window type hint to DIALOG

### DIFF
--- a/panel-plugin/window.cpp
+++ b/panel-plugin/window.cpp
@@ -59,6 +59,7 @@ Window::Window() :
 	gtk_window_set_decorated(m_window, false);
 	gtk_window_set_skip_taskbar_hint(m_window, true);
 	gtk_window_set_skip_pager_hint(m_window, true);
+	gtk_window_set_type_hint(m_window, GDK_WINDOW_TYPE_HINT_DIALOG);
 	gtk_window_stick(m_window);
 	gtk_widget_add_events(GTK_WIDGET(m_window), GDK_BUTTON_PRESS_MASK | GDK_LEAVE_NOTIFY_MASK | GDK_STRUCTURE_MASK);
 	g_signal_connect_slot(m_window, "enter-notify-event", &Window::on_enter_notify_event, this);


### PR DESCRIPTION
Some tiling window managers, like e.g. i3wm, rely on window type hint to determine whether to tile or float a particular window. Windows with hint NORMAL (the default) are thus usually tiled, and dialogs or small or temporary windows, menus, and notifications are more convenient floating.

Reference: http://standards.freedesktop.org/wm-spec/latest/ar01s05.html#idp1333344
