### PR TITLE
Add customizable/higher limit for recently used

### DIFF
--- a/panel-plugin/configuration-dialog.cpp
+++ b/panel-plugin/configuration-dialog.cpp
@@ -253,6 +253,14 @@ void ConfigurationDialog::toggle_display_recent(GtkToggleButton* button)
 
 //-----------------------------------------------------------------------------
 
+void ConfigurationDialog::recent_max_number_changed(GtkSpinButton* button)
+{
+	wm_settings->recent_max_number = gtk_spin_button_get_value_as_int(button);
+	wm_settings->set_modified();
+}
+
+//-----------------------------------------------------------------------------
+
 SearchAction* ConfigurationDialog::get_selected_action(GtkTreeIter* iter) const
 {
 	GtkTreeIter selected_iter;
@@ -634,6 +642,21 @@ GtkWidget* ConfigurationDialog::init_behavior_tab()
 	gtk_box_pack_start(behavior_vbox, m_display_recent, true, true, 0);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(m_display_recent), wm_settings->display_recent);
 	g_signal_connect_slot(m_display_recent, "toggled", &ConfigurationDialog::toggle_display_recent, this);
+
+	// Add value to change maximum number of recently used entries
+	GtkBox* hbox = GTK_BOX(gtk_hbox_new(false, 12));
+	gtk_box_pack_start(behavior_vbox, GTK_WIDGET(hbox), false, false, 0);
+
+	GtkWidget* label = gtk_label_new_with_mnemonic(_("_Maximum number of recently used entries:"));
+	gtk_misc_set_alignment(GTK_MISC(label), 0, 0.5);
+	gtk_box_pack_start(hbox, label, false, false, 0);
+
+	m_recent_max_number = gtk_spin_button_new_with_range(5, 100, 1);
+	gtk_box_pack_start(hbox, m_recent_max_number, false, false, 0);
+	gtk_label_set_mnemonic_widget(GTK_LABEL(label), m_recent_max_number);
+	//wm_settings->recent_max_number = gtk_spin_button_get_value_as_int(button);
+	gtk_spin_button_set_value(GTK_SPIN_BUTTON(m_recent_max_number), (double)wm_settings->recent_max_number);
+	g_signal_connect_slot(m_recent_max_number, "value-changed", &ConfigurationDialog::recent_max_number_changed, this);
 
 	// Create commands section
 	GtkSizeGroup* label_size_group = gtk_size_group_new(GTK_SIZE_GROUP_HORIZONTAL);

--- a/panel-plugin/configuration-dialog.h
+++ b/panel-plugin/configuration-dialog.h
@@ -58,6 +58,7 @@ private:
 	void toggle_hover_switch_category(GtkToggleButton* button);
 	void toggle_remember_favorites(GtkToggleButton* button);
 	void toggle_display_recent(GtkToggleButton* button);
+	void recent_max_number_changed(GtkSpinButton* button);
 
 	SearchAction* get_selected_action(GtkTreeIter* iter = NULL) const;
 	void action_selected(GtkTreeView* view);
@@ -95,6 +96,7 @@ private:
 	GtkWidget* m_hover_switch_category;
 	GtkWidget* m_remember_favorites;
 	GtkWidget* m_display_recent;
+	GtkWidget* m_recent_max_number;
 	std::vector<CommandEdit*> m_commands;
 
 	GtkTreeView* m_actions_view;

--- a/panel-plugin/recent-page.cpp
+++ b/panel-plugin/recent-page.cpp
@@ -29,13 +29,12 @@ using namespace WhiskerMenu;
 //-----------------------------------------------------------------------------
 
 RecentPage::RecentPage(Window* window) :
-	ListPage(wm_settings->recent, window),
-	m_max_items(10)
+	ListPage(wm_settings->recent, window)
 {
 	// Prevent going over max
-	if (wm_settings->recent.size() > m_max_items)
+	if (wm_settings->recent.size() > wm_settings->recent_max_number)
 	{
-		wm_settings->recent.erase(wm_settings->recent.begin() + m_max_items, wm_settings->recent.end());
+		wm_settings->recent.erase(wm_settings->recent.begin() + wm_settings->recent_max_number, wm_settings->recent.end());
 		wm_settings->set_modified();
 	}
 }
@@ -68,7 +67,7 @@ void RecentPage::add(Launcher* launcher)
 			-1);
 
 	// Prevent going over max
-	while (wm_settings->recent.size() > m_max_items)
+	while (wm_settings->recent.size() > wm_settings->recent_max_number)
 	{
 		GtkTreeIter iter;
 		if (gtk_tree_model_iter_nth_child(GTK_TREE_MODEL(store), &iter, NULL, wm_settings->recent.size() - 1))

--- a/panel-plugin/settings.cpp
+++ b/panel-plugin/settings.cpp
@@ -101,6 +101,7 @@ Settings::Settings() :
 	position_search_alternate(false),
 	position_commands_alternate(false),
 	position_categories_alternate(false),
+	recent_max_number(10),
 
 	menu_width(400),
 	menu_height(500)
@@ -179,6 +180,7 @@ void Settings::load(char* file)
 	position_search_alternate = xfce_rc_read_bool_entry(rc, "position-search-alternate", position_search_alternate);
 	position_commands_alternate = xfce_rc_read_bool_entry(rc, "position-commands-alternate", position_commands_alternate) && position_search_alternate;
 	position_categories_alternate = xfce_rc_read_bool_entry(rc, "position-categories-alternate", position_categories_alternate);
+	recent_max_number = std::max(5, xfce_rc_read_int_entry(rc, "recent-max-number", recent_max_number));
 
 	menu_width = std::max(300, xfce_rc_read_int_entry(rc, "menu-width", menu_width));
 	menu_height = std::max(400, xfce_rc_read_int_entry(rc, "menu-height", menu_height));
@@ -272,6 +274,7 @@ void Settings::save(char* file)
 	xfce_rc_write_bool_entry(rc, "position-search-alternate", position_search_alternate);
 	xfce_rc_write_bool_entry(rc, "position-commands-alternate", position_commands_alternate);
 	xfce_rc_write_bool_entry(rc, "position-categories-alternate", position_categories_alternate);
+	xfce_rc_write_int_entry(rc, "recent-max-number", recent_max_number);
 
 	xfce_rc_write_int_entry(rc, "menu-width", menu_width);
 	xfce_rc_write_int_entry(rc, "menu-height", menu_height);

--- a/panel-plugin/settings.h
+++ b/panel-plugin/settings.h
@@ -79,6 +79,7 @@ public:
 	bool position_search_alternate;
 	bool position_commands_alternate;
 	bool position_categories_alternate;
+	unsigned int recent_max_number;
 
 	enum Commands
 	{


### PR DESCRIPTION
I set the Recently Used as initial view. However since it's limited to 10 entries and the XFCE menu categories can be larger, there can be some white space. This is an attempt to give users option to get rid of the white space and icrease the limit. Please consider (something like) this.

This is the reason (few more items would fit nicely):
![whisker](https://cloud.githubusercontent.com/assets/1071643/3142539/4c13b3fe-e9c4-11e3-8efb-c8ea246d8136.png)
