### PR TITLE
add an option "flat_button" which acts in a similar way to the same option in xfce-panel's tasklist plugin

### DIFF
--- a/panel-plugin/configuration-dialog.cpp
+++ b/panel-plugin/configuration-dialog.cpp
@@ -482,6 +482,12 @@ GtkWidget* ConfigurationDialog::init_appearance_tab()
 	gtk_label_set_mnemonic_widget(GTK_LABEL(label), m_button_style);
 	g_signal_connect_slot(m_button_style, "changed", &ConfigurationDialog::style_changed, this);
 
+	// Add an option to use a flat button or not
+	m_flat_button = gtk_check_button_new_with_mnemonic(_("Flat button"));
+	gtk_box_pack_start(hbox, m_flat_button, true, true, 0);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(m_flat_button), wm_settings->flat_button);
+	g_signal_connect_slot(m_flat_button, "toggled", &ConfigurationDialog::toggle_flat_button, this);
+	
 	// Add title selector
 	hbox = GTK_BOX(gtk_hbox_new(false, 12));
 	gtk_box_pack_start(panel_vbox, GTK_WIDGET(hbox), false, false, 0);
@@ -798,6 +804,16 @@ GtkWidget* ConfigurationDialog::init_search_actions_tab()
 	}
 
 	return page;
+}
+
+//-----------------------------------------------------------------------------
+
+void ConfigurationDialog::toggle_flat_button(GtkToggleButton* button)
+{
+	wm_settings->flat_button = gtk_toggle_button_get_active(button);
+	wm_settings->set_modified();
+	m_plugin->set_flat_button(gtk_toggle_button_get_active(button));
+	m_plugin->reload();
 }
 
 //-----------------------------------------------------------------------------

--- a/panel-plugin/configuration-dialog.h
+++ b/panel-plugin/configuration-dialog.h
@@ -53,6 +53,7 @@ private:
 	void style_changed(GtkComboBox* combo);
 	void title_changed(GtkEditable* editable);
 	void choose_icon();
+	void toggle_flat_button(GtkToggleButton* button);
 
 	void toggle_button_single_row(GtkToggleButton* button);
 	void toggle_hover_switch_category(GtkToggleButton* button);
@@ -81,6 +82,7 @@ private:
 	GtkWidget* m_show_generic_names;
 	GtkWidget* m_show_descriptions;
 	GtkWidget* m_show_hierarchy;
+	GtkWidget* m_flat_button;
 	GtkWidget* m_position_search_alternate;
 	GtkWidget* m_position_commands_alternate;
 	GtkWidget* m_position_categories_alternate;

--- a/panel-plugin/plugin.cpp
+++ b/panel-plugin/plugin.cpp
@@ -123,7 +123,10 @@ Plugin::Plugin(XfcePanelPlugin* plugin) :
 
 	// Create toggle button
 	m_button = xfce_panel_create_toggle_button();
-	gtk_button_set_relief(GTK_BUTTON(m_button), GTK_RELIEF_NONE);
+
+	// Set the application button relief style
+	set_relief_style();
+
 	gtk_button_set_focus_on_click(GTK_BUTTON(m_button), false);
 	g_signal_connect_slot(m_button, "button-press-event", &Plugin::button_clicked, this);
 	gtk_widget_show(m_button);
@@ -478,6 +481,32 @@ void Plugin::popup_menu(bool at_cursor, bool activate_button)
 	{
 		m_window->show(NULL, true);
 	}
+}
+
+//-----------------------------------------------------------------------------
+
+void Plugin::set_flat_button(bool flat_button) {
+    wm_settings->flat_button = flat_button;
+    set_relief_style();
+    wm_settings->set_modified();
+}
+
+//-----------------------------------------------------------------------------
+
+bool Plugin::get_flat_button() const {
+    return wm_settings->flat_button;
+}
+
+//-----------------------------------------------------------------------------
+
+void Plugin::set_relief_style() {
+    // GTK_RELIEF_NORMAL allows themes to style the default button when it is not hovered (prelight)
+    // If 'flat_button' is true, we go back to the previous relief style, which is none at all (default)
+    GtkReliefStyle button_relief = GTK_RELIEF_NONE;
+    if (!wm_settings->flat_button) {
+        button_relief = GTK_RELIEF_NORMAL;
+    }
+    gtk_button_set_relief(GTK_BUTTON(m_button), button_relief);
 }
 
 //-----------------------------------------------------------------------------

--- a/panel-plugin/plugin.h
+++ b/panel-plugin/plugin.h
@@ -50,12 +50,14 @@ public:
 	std::string get_button_title() const;
 	static std::string get_button_title_default();
 	std::string get_button_icon_name() const;
+       bool get_flat_button() const;
 
 	void reload();
 	void set_button_style(ButtonStyle style);
 	void set_button_title(const std::string& title);
 	void set_button_icon_name(const std::string& icon);
-	void set_configure_enabled(bool enabled);
+       void set_configure_enabled(bool enabled);
+       void set_flat_button(bool);
 
 private:
 	gboolean button_clicked(GtkWidget*, GdkEvent* event);
@@ -71,6 +73,7 @@ private:
 	void show_about();
 	gboolean size_changed(XfcePanelPlugin*, gint size);
 	void popup_menu(bool at_cursor, bool activate_button);
+       void set_relief_style();
 
 private:
 	XfcePanelPlugin* m_plugin;

--- a/panel-plugin/settings.cpp
+++ b/panel-plugin/settings.cpp
@@ -85,7 +85,8 @@ Settings::Settings() :
 	button_icon_name("xfce4-whiskermenu"),
 	button_title_visible(false),
 	button_icon_visible(true),
-        button_single_row(false),
+	button_single_row(false),
+	flat_button(true),
 
 	launcher_show_name(true),
 	launcher_show_description(true),
@@ -164,6 +165,7 @@ void Settings::load(char* file)
 	button_single_row = xfce_rc_read_bool_entry(rc, "button-single-row", button_single_row);
 	button_title_visible = xfce_rc_read_bool_entry(rc, "show-button-title", button_title_visible);
 	button_icon_visible = xfce_rc_read_bool_entry(rc, "show-button-icon", button_icon_visible);
+	flat_button = xfce_rc_read_bool_entry(rc, "flat_button", flat_button);
 
 	launcher_show_name = xfce_rc_read_bool_entry(rc, "launcher-show-name", launcher_show_name);
 	launcher_show_description = xfce_rc_read_bool_entry(rc, "launcher-show-description", launcher_show_description);
@@ -173,6 +175,7 @@ void Settings::load(char* file)
 	category_icon_size = xfce_rc_read_int_entry(rc, "category-icon-size", category_icon_size);
 
 	load_hierarchy = xfce_rc_read_bool_entry(rc, "load-hierarchy", load_hierarchy);
+
 	favorites_in_recent = xfce_rc_read_bool_entry(rc, "favorites-in-recent", favorites_in_recent);
 
 	display_recent = xfce_rc_read_bool_entry(rc, "display-recent-default", display_recent);
@@ -266,6 +269,7 @@ void Settings::save(char* file)
 	xfce_rc_write_int_entry(rc, "category-icon-size", category_icon_size);
 
 	xfce_rc_write_bool_entry(rc, "load-hierarchy", load_hierarchy);
+	xfce_rc_write_bool_entry(rc, "flat_button", flat_button);
 	xfce_rc_write_bool_entry(rc, "favorites-in-recent", favorites_in_recent);
 
 	xfce_rc_write_bool_entry(rc, "display-recent-default", display_recent);

--- a/panel-plugin/settings.h
+++ b/panel-plugin/settings.h
@@ -64,6 +64,7 @@ public:
 	bool button_title_visible;
 	bool button_icon_visible;
 	bool button_single_row;
+	bool flat_button;
 
 	bool launcher_show_name;
 	bool launcher_show_description;


### PR DESCRIPTION
The single reason why I needed this was I was trying to theme the button that whiskermenu adds to the panel.

I was trying to add a transparent png with the pixmap engine, and thus needed to theme "state = NORMAL", however it was hard-coded as GTK_RELIEF_NONE. Rather than just changing the value manually in the code, I added a single checkbox next to the Display options for the icon.

Checking it sets the button's relief to GTK_RELIEF_NONE (by default, and that's the current setting)
Unchecking it sets the button's relief to GTK_RELIEF_NORMAL
