### PR TITLE
Make new shortcuts executable after adding them to the desktop

### DIFF
--- a/panel-plugin/page.cpp
+++ b/panel-plugin/page.cpp
@@ -309,6 +309,10 @@ void Page::add_selected_to_desktop()
 		g_error_free(error);
 	}
 
+	gchar* command_line = g_strdup_printf("chmod a+rx %s", g_file_get_path(destination_file));
+	xfce_spawn_command_line_on_screen (NULL, command_line, FALSE, FALSE, NULL);
+	g_free (command_line);
+
 	g_object_unref(destination_file);
 	g_object_unref(source_file);
 	g_object_unref(desktop_folder);


### PR DESCRIPTION
Problem
----------

- Right-click an application and select "Add to Desktop"
- The application is successfully added to the desktop but the shortcut is not executable
- When the user runs the application, he/she needs to confirm via a dialog that the shortcut should be executable.

It's a bit tedious and annoying for the user. The fact that Xfce shows that warning dialog is good and it's there to protect users against downloaded files mostly. But in this case the copy of the file originates from the user him/herself and with the purpose of running the application from the desktop.

Solution
----------

Feel free to review the code and change things as you see fit. I relied on xfce_spawn_command_line_on_screen to make a system call to chmod. There's probably other ways to do this. I'm using a temporary gchar which I then free up. In any case, the code was tested and works fine. The resulting desktop shortcuts are runnable from the get go and without the need for the user to make them executable.
