### PR TITLE
Search filter improvements

### DIFF
--- a/panel-plugin/launcher.cpp
+++ b/panel-plugin/launcher.cpp
@@ -170,7 +170,8 @@ Launcher::Launcher(GarconMenuItem* item) :
 	}
 
 	// Create search text for display name
-	m_search_name = normalize(m_display_name);
+	m_search_name = normalize(name);
+	m_search_generic_name = normalize(generic_name);
 
 	// Create search text for command
 	const gchar* command = garcon_menu_item_get_command(m_item);
@@ -274,6 +275,12 @@ void Launcher::run(GdkScreen* screen) const
 int Launcher::search(const Query& query)
 {
 	int match = query.match(m_search_name);
+	if (match != G_MAXINT)
+	{
+		return match;
+	}
+
+	match = query.match(m_search_generic_name);
 	if (match != G_MAXINT)
 	{
 		return match;

--- a/panel-plugin/launcher.h
+++ b/panel-plugin/launcher.h
@@ -70,6 +70,7 @@ private:
 	GarconMenuItem* m_item;
 	const gchar* m_display_name;
 	std::string m_search_name;
+	std::string m_search_generic_name;
 	std::string m_search_comment;
 	std::string m_search_command;
 };

--- a/panel-plugin/query.cpp
+++ b/panel-plugin/query.cpp
@@ -113,7 +113,7 @@ int Query::match(const std::string& haystack) const
 		}
 	}
 
-	// Check if haystack contains query as characters
+	// Check if haystack contains all the characters of query, in order
 	bool characters_start_words = true;
 	bool start_word = true;
 	bool started = false;
@@ -143,13 +143,14 @@ int Query::match(const std::string& haystack) const
 	int result = INT_MAX;
 	if (*query_string == 0)
 	{
-		result = characters_start_words ? 5 : 7;
+		// Sufficiently large to sort after more relevant matches in other fields
+		result = characters_start_words ? 500 : 700;
 	}
 
 	// Check if haystack contains query
-	if ((result > 5) && (pos != std::string::npos))
+	if ((result > 500) && (pos != std::string::npos))
 	{
-		result = 6;
+		result = 600;
 	}
 
 	return result;


### PR DESCRIPTION
Lovely (and unsurprisingly) how you got patroned into Xfce official. Hope PRs are still welcome here.

The first commit solves the case when the (noob) user might not be aware that the "image viewer" is called Ristretto, "calculator" is called SpeedCrunch, "word" is called Libre Office Writer, ...

The second commit solves the issue of a lot of completely irrelevant stuff sorted in front.
