### PR TITLE
update the translation of Regular expression in Chinese.

### DIFF
--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -193,7 +193,7 @@ msgstr "面板按钮"
 
 #: ../panel-plugin/configuration-dialog.cpp:767
 msgid "Pattern"
-msgstr "图案"
+msgstr "模式"
 
 #: ../panel-plugin/configuration-dialog.cpp:653
 msgid "Position _search entry next to panel button"
@@ -357,11 +357,11 @@ msgstr "锁定屏幕 (_L)"
 
 #: ../panel-plugin/configuration-dialog.cpp:828
 msgid "_Pattern:"
-msgstr "图案 (_P): "
+msgstr "模式 (_P): "
 
 #: ../panel-plugin/configuration-dialog.cpp:852
 msgid "_Regular expression"
-msgstr "一般表达式 (_R)"
+msgstr "正则表达式 (_R)"
 
 #: ../panel-plugin/configuration-dialog.cpp:523
 msgid "_Title:"


### PR DESCRIPTION
Dear developers, 

It's better to use following Chinese words for pattern and regular expression.

* Ref: https://zh.wikipedia.org/wiki/%E6%AD%A3%E5%88%99%E8%A1%A8%E8%BE%BE%E5%BC%8F