### PR TITLE
Fix GTK3 theming

### DIFF
--- a/panel-plugin/window.cpp
+++ b/panel-plugin/window.cpp
@@ -77,6 +77,16 @@ WhiskerMenu::Window::Window(Plugin* plugin) :
 	// Create the window
 	m_window = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
 	gtk_widget_set_name(GTK_WIDGET(m_window), "whiskermenu-window");
+
+	// Add CSS provider
+	provider = gtk_css_provider_new();
+	context = gtk_widget_get_style_context(GTK_WIDGET(m_window));
+	gtk_style_context_add_provider(context, GTK_STYLE_PROVIDER(provider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+	g_object_unref(provider);
+
+	// Use panel theme by default
+	gtk_style_context_add_class(context, "xfce4-panel");
+
 	// Untranslated window title to allow window managers to identify it; not visible to users.
 	gtk_window_set_title(m_window, "Whisker Menu");
 	gtk_window_set_modal(m_window, true);

--- a/panel-plugin/window.h
+++ b/panel-plugin/window.h
@@ -105,6 +105,9 @@ private:
 
 	GtkWindow* m_window;
 
+	GtkStyleContext* context;
+	GtkCssProvider* provider;
+
 	GtkStack* m_window_stack;
 	GtkSpinner* m_window_load_spinner;
 


### PR DESCRIPTION
Themes like the Numix theme do not work since the move to gtk3.
Fix this by adding a css provider for the plugin window and add xfce4-panel's css class to default to xfce4-panel's css.