### PR TITLE
Fix focus issues with left and right arrow keys in icon view during search

### DIFF
--- a/panel-plugin/window.cpp
+++ b/panel-plugin/window.cpp
@@ -642,6 +642,29 @@ gboolean WhiskerMenu::Window::on_key_press_event(GtkWidget* widget, GdkEvent* ev
 		}
 	}
 
+	//Allows for scrolling with left and right keys if in icon view
+	if (GTK_IS_ICON_VIEW(view) && ((key_event->keyval == GDK_KEY_Left) || (key_event->keyval == GDK_KEY_Right)))
+	{
+		GtkWidget* search = GTK_WIDGET(m_search_entry);
+		if ((widget == search) || (gtk_window_get_focus(m_window) == search))
+		{
+			gtk_widget_grab_focus(view);
+		}
+		if (gtk_window_get_focus(m_window) == view)
+		{
+			GtkTreePath* path = page->get_view()->get_selected_path();
+			if (path)
+			{
+				gtk_tree_path_free(path);
+			}
+			else
+			{
+				page->select_first();
+				return GDK_EVENT_STOP;
+			}
+		}
+	}
+
 	return GDK_EVENT_PROPAGATE;
 }
 


### PR DESCRIPTION
When searching for applications using icon view, at the moment only the up and down keys can change focus to the scrolling list of applications. This is fine for the other views, where there is only a single column with many rows. 

However, in the multi-column icon view, you cannot currently hit the right arrow key during a search to select the second application listed. The left and right arrow keys continue to move the cursor in the search box. When rapidly searching for an application, this can be very annoying, as there are often two applications with similar names, and I often want the application one or two to the right. 

For example, Discord and Disks (Gnome Disk Utility). When I type "Dis", discord comes up first, and I need to move one to the right to open Disks instead. I cannot do this, and instead must either continue typing almost the entire software name or click the application.

While in theory this behavior could be desirable in some circumstances, to allow users to edit the text in the search box by moving the text cursor, it creates inconsistent focus behavior that would likely seem buggy to a user. If I tap right, nothing happens. If I tap up or down first, then right, now I can move to the right.

This pull request gives focus to the scrolling list if the left or right keys are hit, only if the user is using icon view. This creates a major ergonomic improvement when trying to rapidly open applications via search.