### PR TITLE
Fix the menu taking two events to close

### DIFF
--- a/panel-plugin/plugin.cpp
+++ b/panel-plugin/plugin.cpp
@@ -364,12 +364,9 @@ gboolean Plugin::remote_event(const gchar* name, const GValue* value)
 		return false;
 	}
 
-	// Ignore event if last shown through remote event;
-	// needed for toggling as remote event happens after focus is lost
 	if (m_menu_shown && !wm_settings->stay_on_focus_out)
 	{
 		m_menu_shown = false;
-		return true;
 	}
 
 	if (gtk_widget_get_visible(m_window->get_widget()))


### PR DESCRIPTION
While the menu is open it takes two events from xfce4-popup-whiskermenu
to close the menu.

This patch removes remaining code that should have already been removed
in 26001c4b3ecb.